### PR TITLE
Adds custom deployment steps

### DIFF
--- a/config/custom-deploy.sh
+++ b/config/custom-deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This is a custom deployment script. It will add deployment steps that are not
+# covered by hooks/common/post-code-update/drush-env-switch.sh
+# 
+# If STOP_EXECUTION is set to true then the deployment script will exit and
+# this script will be the only one to run.
+#
+# 
+STOP_EXECUTION=false
+
+echo "Running custom deployment steps"

--- a/hooks/common/post-code-update/drush-env-switch.sh
+++ b/hooks/common/post-code-update/drush-env-switch.sh
@@ -2,6 +2,7 @@
 #
 # Cloud Hook: drush-env-switch
 #
+set -e
 
 site=$1
 env=$2
@@ -37,6 +38,18 @@ echo "Running database update"
 drush @$drush_alias updatedb -y
 echo "Clearing caches"
 drush @$drush_alias cc all
+
+STOP_EXECUTION=false
+if [ -f  "config/custom-deploy.sh" ]; then
+  echo "Running pre deploy hook"
+  source "config/custom-deploy.sh"
+  if [ $STOP_EXECUTION = true ]; then
+    echo "Stopping execution after pre deploy hook"
+    exit 0
+  fi
+else
+  echo "No pre deploy hook included"
+fi
 
 echo "Checking drupal boostrap."
 drupal=$(drush @$drush_alias status | grep -e "Drupal bootstrap" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')


### PR DESCRIPTION
## Description

This allows people to insert custom deployment steps. It adds `config/custom-deploy.sh` and sources from `drush-env-switch.sh`.

It includes a flag `STOP_EXECUTION` that defaults to `false`. If set to `true` then  `drush-env-switch.sh` exits and only `custom-deploy.sh` is run.

This is in response to https://jira.govdelivery.com/browse/CIVIC-4164
## AC
- [x] @dkinzer agrees
- [ ] Tested on Acquia
- [ ] Documentation updated
- [ ] Some kind of test?
