### PR TITLE
Eliminate blank line at beginning of alias PHP file

### DIFF
--- a/.ahoy/site/.scripts/drush.alias.sh
+++ b/.ahoy/site/.scripts/drush.alias.sh
@@ -3,8 +3,7 @@ cp -L ./assets/drush/aliases.local.php ~/.drush
 name=$(ahoy utils name)
 touch ~/.drush/$name.aliases.drushrc.php
 
-echo '
-<?php
+echo '<?php
 // Added by NuCivic.
 $aliases_local = realpath(dirname(__FILE__)) . "/aliases.local.php";
 if (file_exists($aliases_local)) {


### PR DESCRIPTION
Eliminate blank line at beginning of alias php file, which causes headers to be sent prematurely. For instance, we get a lot of these during build processes and even normal drush commands:

```
Cannot modify header information - headers already sent by (output   [warning]
started at /root/.drush/usda-nal.aliases.drushrc.php:2)
```