### PR TITLE
Add memcache-lock config to settings.acquia.php

### DIFF
--- a/assets/sites/default/settings.acquia.php
+++ b/assets/sites/default/settings.acquia.php
@@ -10,6 +10,10 @@ if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
     $conf['cache_backends'][] = './sites/all/modules/contrib/memcache/memcache.inc';
     $conf['cache_default_class'] = 'MemCacheDrupal';
     $conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
+
+    # hotfixed for Acquia ticket 679235
+    # # Move semaphore out of the database and into memory for performance purposes
+    $conf['lock_inc'] = './sites/all/modules/contrib/memcache/memcache-lock.inc';
   }
 
   $env = getenv('AH_SITE_ENVIRONMENT');
@@ -66,7 +70,7 @@ if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
       'api/action/datastore/search.json',
     );
   }
-  
+
   // ODSM edit forms.
   $high_memory_paths[] = 'admin/config/services/odsm/edit';
 

--- a/dkan/test/features/group.editor.feature
+++ b/dkan/test/features/group.editor.feature
@@ -30,9 +30,6 @@ Feature: Site Manager administer groups
       | Gabriel | Group A | administrator member | Active            |
       | Katie   | Group A | member               | Active            |
       | Jaz     | Group A | member               | Pending           |
-    And resources:
-      | title    | publisher | format | author | published | description |
-      | GER1     | Group A   | csv    | Katie  | Yes       |             |
 
   Scenario: Edit group as group administrator
     Given I am logged in as "Gabriel"
@@ -140,15 +137,21 @@ Feature: Site Manager administer groups
     Then I should see "Total members: 3"
 
   Scenario: View the number of content on group as group administrator
-    Given I am logged in as "Gabriel"
+    Given resources:
+      | title    | publisher | format | author | published | description |
+      | content2 | Group A   | csv    | Katie  | Yes       |             |
+    And I am logged in as "Gabriel"
     And I am on "Group A" page
     And I click "Group"
     When I click "People"
     Then I should see "Total content: 1"
 
   Scenario: Edit resource content created by others on group as editor
-    Given I am logged in as "Martin"
-    And I am on "GER1" page
+    Given resources:
+      | title    | publisher | format | author | published | description |
+      | content1 | Group A   | csv    | Katie  | Yes       |             |
+    And I am logged in as "Martin"
+    And I am on "content1" page
     Then I should see "Edit"
 
   Scenario: Show correct number of groups to which user belongs


### PR DESCRIPTION
The volume of post-deployment steps happening in deploy.sh will cause the production site to be down for an unforgivable amount of time. Sending locks to memcache to mitigate a menu rebuild stampede allowed the site to remain 'up' while the deployment finished.
