### PR TITLE
Fix hsts_subdomain implementation

### DIFF
--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -168,7 +168,8 @@ if (isset($data_config['seckit']) && $data_config['seckit']['enable']) {
   $seckit_ssl = array(
     'hsts' => $conf['default']['seckit']['hsts'],
     'hsts_max_age' => $conf['default']['seckit']['hsts_max_age'],
-    'hsts_sudomains' => $conf['default']['seckit']['hsts_subdomains'],
+    'hsts_subdomains' => $conf['default']['seckit']['hsts_subdomains'],
+    'hsts_preload' => $conf['default']['seckit']['hsts_preload'],
   );
 
   $conf['seckit_ssl'] = $seckit_ssl;

--- a/build.make
+++ b/build.make
@@ -45,7 +45,11 @@ projects:
   clamav:
     version: 1.x-dev
   seckit:
-    version: '1.9'
+	  download:
+      type: git
+      url: https://git.drupal.org/project/seckit.git
+      branch: 7.x-1.x
+      revision: 19843dc4bf7b92b054f9f38a964edbf8da4e9982
   dkan_acquia_expire:
     type: module
     download:

--- a/config/config.php
+++ b/config/config.php
@@ -113,6 +113,7 @@ $conf = array (
       'hsts' => 1,
       'hsts_max_age' => '1000',
       'hsts_subdomains' => 0,
+      'hsts_preload' => 0,
     ),
     'stage_file_proxy_files' => 
     array (

--- a/config/config.yml
+++ b/config/config.yml
@@ -59,6 +59,7 @@ default:
     hsts: 1
     hsts_max_age: '1000'
     hsts_subdomains: 0
+    hsts_preload: 0
   stage_file_proxy_files: []
   stage_file_proxy_origin: changeme
 dkan_dash: []


### PR DESCRIPTION
We need the hsts preload option
```
  seckit:
    enable: true
    hsts: 1
    hsts_max_age: '31536000'
    hsts_subdomains: 1
    hsts_preload: 1
```

Upgrading the Security Kit module to the dev version adds the option.

## QA Steps
- enable seckit
- Update config/config.yml to match the settings above
- Run `ahoy build config`
- clear cache
- Open the browser inspector and click on the network tab
- reload the page and click on the page title to view the headers
- confirm you see the *includeSubDomains; preload* bit in the Strict-Transport-Security results

![security_kit](https://user-images.githubusercontent.com/314172/39443968-be627d8c-4c7b-11e8-867f-c9c7fec23fcd.png)

